### PR TITLE
refs #26: Fix warning in init.rb for duplicate issue_checklist

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -21,7 +21,7 @@ Redmine::Plugin.register :redmine_issue_checklist do
     map.project_module :issue_tracking do |map|
       map.permission :view_checklists, {}
       map.permission :done_checklists, { issue_checklist: :done }
-      map.permission :edit_checklists, { issue_checklist: :delete, issue_checklist: :done }
+      map.permission :edit_checklists, { issue_checklist: [:delete, :done] }
     end
   end
 


### PR DESCRIPTION
Fix warning: init.rb:24: warning: key :issue_checklist is duplicated and overwritten on line 24
Only a slight syntactic change, should not have any impact. Tested with Redmine 3.4 only